### PR TITLE
abbreviate package names

### DIFF
--- a/javalib/agent-tests/src/test/java/stackparam/ThrowableTest.java
+++ b/javalib/agent-tests/src/test/java/stackparam/ThrowableTest.java
@@ -9,10 +9,12 @@ public class ThrowableTest {
 
     @Test
     public void testStackTraceElementToString() throws Exception {
-        String expected = "[this=" + this + ", boolArg=true, byteArg=100, " +
+        String expected = "[this=" + this.toString().replace("stackparam.", "s.") +
+                ", boolArg=true, byteArg=100, " +
                 "charArg=e, shortArg=102, intArg=103, longArg=104, " +
                 "floatArg=105.6, doubleArg=106.7, nullArg=null, " +
-                "objectExactArg=" + CONST_OBJ + ", stringVarArgs=[foo, bar, baz]]";
+                "objectExactArg=" + CONST_OBJ.toString().replace("java.lang", "j.l") +
+                ", stringVarArgs=[foo, bar, baz]]";
         StackTraceElement elem = getTestElement();
         String traceStr = elem.toString();
         traceStr = traceStr.substring(traceStr.indexOf('['));


### PR DESCRIPTION
This changes the displayed class name from `really.long.package.name.Class` to `r.l.p.n.Class` for classes that have not overridden Object.toString().  Also replaces literal newlines with `\n`.